### PR TITLE
Disable spellchecking on Darwin

### DIFF
--- a/skytemple_ssb_debugger/controller/main.py
+++ b/skytemple_ssb_debugger/controller/main.py
@@ -110,7 +110,14 @@ class MainController:
         # mapname_{enter,acting,{sss_name_with_extension}}
         self._tree_branches: Dict[str, Gtk.TreeIter] = {}
 
-        self.builder.get_object('menu_spellcheck_enabled').set_active(self.settings.get_spellcheck_enabled())
+        spellcheck_enabled_item = self.builder.get_object('menu_spellcheck_enabled')
+        if sys.platform.startswith('darwin'):
+            # Disable spellchecking on darwin for now since it causes run-time errors that make the UI unusable
+            # TODO: investigate the issue further
+            spellcheck_enabled_item.set_active(False)
+            spellcheck_enabled_item.hide()
+        else:
+            spellcheck_enabled_item.set_active(self.settings.get_spellcheck_enabled())
 
         # Source editor style schema
         self.style_scheme_manager = StyleSchemeManager()


### PR DESCRIPTION
Disable spellchecking on darwin for now since it causes run-time errors that make the UI unusable