### PR TITLE
Automatically update device capacity (ROM size) on save

### DIFF
--- a/skytemple_ssb_debugger/context/standalone.py
+++ b/skytemple_ssb_debugger/context/standalone.py
@@ -101,7 +101,7 @@ class StandaloneDebuggerControlContext(AbstractDebuggerControlContext):
 
     def save_rom(self):
         self._check_loaded()
-        self._rom.saveToFile(self._rom_filename)
+        self._rom.saveToFile(self._rom_filename, updateDeviceCapacity=True)
 
     def get_static_data(self) -> Pmd2Data:
         self._check_loaded()


### PR DESCRIPTION
This is only relevant for the standalone version of the app.