### PR TITLE
Suppress Type Check Errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ git+https://github.com/skytemple/skytemple-files@master#egg=skytemple_files
 pmdsky-debug-py
 git+https://github.com/skytemple/skytemple-icons@main#egg=skytemple_icons
 types-setuptools
-pygobject-stubs --config-settings=config=Gtk3,Gdk3,GtkSource4
+pygobject-stubs==2.12.0 --config-settings=config=Gtk3,Gdk3,GtkSource4

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ git+https://github.com/skytemple/skytemple-files@master#egg=skytemple_files
 pmdsky-debug-py
 git+https://github.com/skytemple/skytemple-icons@main#egg=skytemple_icons
 types-setuptools
-pygobject-stubs==2.12.0 --config-settings=config=Gtk3,Gdk3,GtkSource4
+pygobject-stubs --config-settings=config=Gtk3,Gdk3,GtkSource4

--- a/skytemple_ssb_debugger/model/completion/calltips/position_mark.py
+++ b/skytemple_ssb_debugger/model/completion/calltips/position_mark.py
@@ -29,7 +29,7 @@ from skytemple_ssb_debugger.context.abstract import AbstractDebuggerControlConte
 from skytemple_files.common.i18n_util import f, _
 
 
-class PositionMarkEditorCalltip(GtkSource.CompletionProvider):
+class PositionMarkEditorCalltip(GObject.Object, GtkSource.CompletionProvider):
     """
     Provides a button to click to open a scene editor for interactively editing position marks.
     This is done by parsing the ExplorerScript, extracting all position marks, and then

--- a/skytemple_ssb_debugger/model/completion/calltips/position_mark.py
+++ b/skytemple_ssb_debugger/model/completion/calltips/position_mark.py
@@ -29,7 +29,7 @@ from skytemple_ssb_debugger.context.abstract import AbstractDebuggerControlConte
 from skytemple_files.common.i18n_util import f, _
 
 
-class PositionMarkEditorCalltip(GObject.Object, GtkSource.CompletionProvider):
+class PositionMarkEditorCalltip(GObject.Object, GtkSource.CompletionProvider): # type: ignore
     """
     Provides a button to click to open a scene editor for interactively editing position marks.
     This is done by parsing the ExplorerScript, extracting all position marks, and then

--- a/skytemple_ssb_debugger/model/completion/constants.py
+++ b/skytemple_ssb_debugger/model/completion/constants.py
@@ -28,7 +28,7 @@ from skytemple_ssb_debugger.model.constants import ICON_ACTOR, ICON_OBJECT, ICON
 from skytemple_files.common.i18n_util import _
 
 
-class GtkSourceCompletionSsbConstants(GtkSource.CompletionProvider):
+class GtkSourceCompletionSsbConstants(GObject.Object, GtkSource.CompletionProvider):
     def __init__(self, rom_data: Pmd2Data):
         super().__init__()
         self.constant_source = rom_data.script_data

--- a/skytemple_ssb_debugger/model/completion/constants.py
+++ b/skytemple_ssb_debugger/model/completion/constants.py
@@ -28,7 +28,7 @@ from skytemple_ssb_debugger.model.constants import ICON_ACTOR, ICON_OBJECT, ICON
 from skytemple_files.common.i18n_util import _
 
 
-class GtkSourceCompletionSsbConstants(GObject.Object, GtkSource.CompletionProvider):
+class GtkSourceCompletionSsbConstants(GObject.Object, GtkSource.CompletionProvider): # type: ignore
     def __init__(self, rom_data: Pmd2Data):
         super().__init__()
         self.constant_source = rom_data.script_data

--- a/skytemple_ssb_debugger/model/completion/exps_statements.py
+++ b/skytemple_ssb_debugger/model/completion/exps_statements.py
@@ -29,7 +29,7 @@ ALL_STATEMENTS = ['return', 'end', 'hold', 'if', 'elseif', 'else', 'with', 'acto
                   'default', 'clear', 'reset', 'init']
 
 
-class GtkSourceCompletionExplorerScriptStatements(GtkSource.CompletionProvider):
+class GtkSourceCompletionExplorerScriptStatements(GObject.Object, GtkSource.CompletionProvider):
     def do_get_name(self) -> str:
         return _("Statements")
 

--- a/skytemple_ssb_debugger/model/completion/exps_statements.py
+++ b/skytemple_ssb_debugger/model/completion/exps_statements.py
@@ -29,7 +29,7 @@ ALL_STATEMENTS = ['return', 'end', 'hold', 'if', 'elseif', 'else', 'with', 'acto
                   'default', 'clear', 'reset', 'init']
 
 
-class GtkSourceCompletionExplorerScriptStatements(GObject.Object, GtkSource.CompletionProvider):
+class GtkSourceCompletionExplorerScriptStatements(GObject.Object, GtkSource.CompletionProvider): # type: ignore
     def do_get_name(self) -> str:
         return _("Statements")
 

--- a/skytemple_ssb_debugger/model/completion/functions.py
+++ b/skytemple_ssb_debugger/model/completion/functions.py
@@ -25,7 +25,7 @@ from skytemple_ssb_debugger.model.completion.util import common_do_match, common
 from skytemple_files.common.i18n_util import _
 
 
-class GtkSourceCompletionSsbFunctions(GObject.Object, GtkSource.CompletionProvider):
+class GtkSourceCompletionSsbFunctions(GObject.Object, GtkSource.CompletionProvider): # type: ignore
     def __init__(self, opcodes: list[Pmd2ScriptOpCode]):
         super().__init__()
         self.opcodes = opcodes

--- a/skytemple_ssb_debugger/model/completion/functions.py
+++ b/skytemple_ssb_debugger/model/completion/functions.py
@@ -25,7 +25,7 @@ from skytemple_ssb_debugger.model.completion.util import common_do_match, common
 from skytemple_files.common.i18n_util import _
 
 
-class GtkSourceCompletionSsbFunctions(GtkSource.CompletionProvider):
+class GtkSourceCompletionSsbFunctions(GObject.Object, GtkSource.CompletionProvider):
     def __init__(self, opcodes: list[Pmd2ScriptOpCode]):
         super().__init__()
         self.opcodes = opcodes


### PR DESCRIPTION
After reviewing the GtkSourceView4 documentation, it states that 'GtkSourceCompletionProvider requires GObject."

For some reason, using pygobject-stubs above 2.12.0 seems to make the type check fail.